### PR TITLE
Fix for #54: Remove from DOM when MarkdownEditor is disposed

### DIFF
--- a/MarkdownEditorDemo/Pages/Demo.razor
+++ b/MarkdownEditorDemo/Pages/Demo.razor
@@ -1,12 +1,16 @@
 ﻿@page "/demo"
 
 <div class="col-md-12">
-    <MarkdownEditor @bind-Value="@markdownValue" MaxHeight="300px"
-                    ValueHTMLChanged="@OnMarkdownValueHTMLChanged" AllowResize="true"
-                    SpellChecker="false" @ref="Markdown1" AutoSaveEnabled="true" />
+    @if(isVisible)
+    {
+        <MarkdownEditor @bind-Value="@markdownValue" MaxHeight="300px"
+        ValueHTMLChanged="@OnMarkdownValueHTMLChanged" AllowResize="true"
+        SpellChecker="false" @ref="Markdown1" AutoSaveEnabled="true" />
+    }
 
     <button @onclick="ChangeText">Change text</button>
     <button @onclick="DeleteStorage">Delete Local Storage</button>
+    <button @onclick="ToggleVisibility">Toggle Visibility</button>
     <hr />
 
     <h3>Result</h3>
@@ -36,6 +40,13 @@
                            "```tip\nThis is a tip to highlight some information\n```\n\n" +
                            "```warn\nIf you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. \n```\n\n";
     string markdownHtml;
+
+    bool isVisible = true;
+
+    void ToggleVisibility()
+    {
+        isVisible = !isVisible;
+    }
 
     async Task ChangeText()
     {

--- a/MarkdownEditorDemo/Pages/Preview.razor
+++ b/MarkdownEditorDemo/Pages/Preview.razor
@@ -1,28 +1,41 @@
-﻿@page "/demo"
+﻿@page "/preview"
 
 <div class="col-md-12">
-    @if(isVisible)
-    {
-        <MarkdownEditor @bind-Value="@markdownValue" MaxHeight="300px"
-        ValueHTMLChanged="@OnMarkdownValueHTMLChanged" AllowResize="true"
-        SpellChecker="false" @ref="Markdown1" AutoSaveEnabled="true" />
-    }
 
-    <button @onclick="ChangeText">Change text</button>
-    <button @onclick="DeleteStorage">Delete Local Storage</button>
-    <button @onclick="ToggleVisibility">Toggle Visibility</button>
-    
+    <h1>Control preview mode with the Preview parameter</h1>
+
+    <MarkdownEditor @bind-Value="@markdownValue" MaxHeight="300px" 
+        AllowResize="true" Preview="@_preview"
+        SpellChecker="false" @ref="Markdown1" AutoSaveEnabled="false">
+        <Toolbar>
+            <MarkdownToolbarButton Action="MarkdownAction.Bold" Icon="fa fa-bold" Title="Bold" />
+        </Toolbar>
+    </MarkdownEditor>
+
+    <button @onclick="() => _preview = true">Preview ON</button>
+    <button @onclick="() => _preview = false">Preview OFF</button>
+
     <hr />
 
-    <h3>Result</h3>
-    @((MarkupString)markdownHtml)
+    <h2>Preview mode can be controlled with the Preview parameter</h2>
+    <MarkdownEditor Value="@exampleRazor" Preview="true"></MarkdownEditor>
 
-    <h3>Value</h3>
-    @((MarkupString)markdownValue)
+    <hr />
+    <h2>Enable or disable preview from code using SetPreviewAsync()</h2>
+    <MarkdownEditor Value="@exampleCsharp" Preview="true"></MarkdownEditor>
+
+    <hr />
+    <h2>Preview can be toggled from code using TogglePreviewAsync()</h2>
+    <MarkdownEditor Value="@exampleCsharpToggle" Preview="true"></MarkdownEditor>
+
 </div>
 
 @code {
     MarkdownEditor Markdown1;
+
+    string exampleRazor = "```html\n<MarkdownEditor @ref=\"Markdown1\" Preview=\"true\">\n</MarkdownEditor>\n```";
+    string exampleCsharp = "```csharp\nawait MarkdownEditor1.SetPreviewAsync(true);\n```";
+    string exampleCsharpToggle = "```csharp\nawait MarkdownEditor1.TogglePreviewAsync();\n```";
 
     string markdownValue = "# Markdown Editor for Blazor\nThis component is using [EasyMDE](https://easy-markdown-editor.tk/) " +
                            "to display a nice editor and all functionalities are mapped. See the documentation for more details.\n\n" +
@@ -41,34 +54,5 @@
                            "```tip\nThis is a tip to highlight some information\n```\n\n" +
                            "```warn\nIf you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. If you want to warn a user about something, this is an example. \n```\n\n";
     string markdownHtml;
-
-    bool isVisible = true;
-
-    void ToggleVisibility()
-    {
-        isVisible = !isVisible;
-    }
-
-    async Task ChangeText()
-    {
-        markdownValue = "Test!";
-        await Markdown1.SetValueAsync(markdownValue);
-    }
-
-    async Task DeleteStorage()
-    {
-        await Markdown1.CleanAutoSave();
-    }
-
-    Task OnMarkdownValueChanged(string value)
-    {
-        markdownValue = value;
-        return Task.CompletedTask;
-    }
-
-    Task OnMarkdownValueHTMLChanged(string value)
-    {
-        markdownHtml = value;
-        return Task.CompletedTask;
-    }
+    private bool _preview = true;
 }

--- a/MarkdownEditorDemo/Shared/NavMenu.razor
+++ b/MarkdownEditorDemo/Shared/NavMenu.razor
@@ -18,6 +18,11 @@
             </NavLink>
         </li>
         <li class="nav-item px-3">
+            <NavLink class="nav-link" href="/preview">
+                <span class="oi oi-cloud-upload" aria-hidden="true"></span> Preview
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
             <NavLink class="nav-link" href="/upload">
                 <span class="oi oi-cloud-upload" aria-hidden="true"></span> Upload
             </NavLink>

--- a/PSC.Blazor.Components.MarkdownEditor/JSMarkdownInterop.cs
+++ b/PSC.Blazor.Components.MarkdownEditor/JSMarkdownInterop.cs
@@ -139,5 +139,26 @@
             await jsRuntime.InvokeVoidAsync("setValue", elementId, value);
             await jsRuntime.InvokeVoidAsync("setInitValue", elementId, value);
         }
+
+        /// <summary>
+        /// Toggles preview mode.
+        /// </summary>
+        /// <param name="elementId">The element identifier.</param>
+        /// <returns></returns>
+        public async ValueTask TogglePreview(string elementId)
+        {
+            await jsRuntime.InvokeVoidAsync("togglePreview", elementId);
+        }
+
+        /// <summary>
+        /// Enables or disables the preview
+        /// </summary>
+        /// <param name="elementId">The element identifier.</param>
+        /// <param name="wantedState">If true preview will be enabled</param>
+        /// <returns></returns>
+        public async ValueTask SetPreview(string elementId, bool wantedState)
+        {
+            await jsRuntime.InvokeVoidAsync("setPreview", elementId, wantedState);
+        }
     }
 }

--- a/PSC.Blazor.Components.MarkdownEditor/MarkdownEditor.razor.cs
+++ b/PSC.Blazor.Components.MarkdownEditor/MarkdownEditor.razor.cs
@@ -426,6 +426,12 @@ namespace PSC.Blazor.Components.MarkdownEditor
         public bool SpellChecker { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value controlling whether the preview should be enabled by default (default off).
+        /// </summary>
+        [Parameter]
+        public bool Preview { get; set; } = false;
+
+        /// <summary>
         /// If set, customize the tab size. Defaults to 2.
         /// </summary>
         [Parameter]
@@ -557,6 +563,32 @@ namespace PSC.Blazor.Components.MarkdownEditor
                 await JSModule.NotifyImageUploadError(ElementId, $"The property ImageUploadEndpoint is not specified.");
 
             await InvokeAsync(StateHasChanged);
+        }
+
+        /// <summary>
+        /// Toggles preview mode
+        /// </summary>
+        public async Task TogglePreviewAsync()
+        {
+            if (!Initialized)
+                return;
+
+            await JSModule.TogglePreview(ElementId);
+        }
+
+        /// <summary>
+        /// Enables or disables the preview
+        /// </summary>
+        /// <param name="elementId">The element identifier.</param>
+        public async Task SetPreviewAsync(bool wantedState)
+        {
+            if (!Initialized)
+                return;
+
+            await JSModule.SetPreview(ElementId, wantedState);
+
+            // Keep track of the state to support changing the state with the Preview parameter
+            _currentPreviewState = Preview;
         }
 
         /// <summary>
@@ -751,6 +783,22 @@ namespace PSC.Blazor.Components.MarkdownEditor
             toolbarButtons.Remove(toolbarButton);
         }
 
+        private bool? _currentPreviewState = null;
+
+        protected override async Task OnParametersSetAsync()
+        {
+            // Save initial state
+            if (_currentPreviewState is null)
+            {
+                _currentPreviewState = Preview;
+            }
+
+            if (Initialized && _currentPreviewState != Preview)
+            {
+                await SetPreviewAsync(Preview);
+            }
+        }
+
         /// <summary>
         /// Method invoked after each time the component has been rendered. Note that the component does
         /// not automatically re-render after the completion of any returned <see cref="T:System.Threading.Tasks.Task" />, because
@@ -837,6 +885,7 @@ namespace PSC.Blazor.Components.MarkdownEditor
                         ImageTexts.SizeUnits,
                     },
                     ErrorMessages,
+                    Preview,
                 });
 
                 if (AllowResize != null && (bool)AllowResize)

--- a/PSC.Blazor.Components.MarkdownEditor/wwwroot/js/markdownEditor.js
+++ b/PSC.Blazor.Components.MarkdownEditor/wwwroot/js/markdownEditor.js
@@ -300,6 +300,13 @@ function deleteAllAutoSave() {
 
 function destroy(element, elementId) {
     const instances = _instances || {};
+
+    // Fix for #54: Remove from DOM when MarkdownEditor is disposed
+    const instance = _instances[elementId];
+    if (instance && instance.editor) {
+        instance.editor.toTextArea();
+    }
+
     delete instances[elementId];
 }
 

--- a/PSC.Blazor.Components.MarkdownEditor/wwwroot/js/markdownEditor.js
+++ b/PSC.Blazor.Components.MarkdownEditor/wwwroot/js/markdownEditor.js
@@ -119,10 +119,6 @@ function initialize(dotNetObjectRef, element, elementId, options) {
                         tempDiv.innerHTML = svg;
                         return tempDiv;
                     }
-                    else if (lang === "code" && hljsInstalled) {
-                        const language = hljs.getLanguage(lang) ? lang : 'plaintext';
-                        return hljs.highlight(code, { language }).value;
-                    }
                     else if (lang === "att") {
                         return '<div class="me-alert callout attention"><p class="title">' +
                             '<span class="me-icon icon-attention"></span> Attention</p><p>' +
@@ -156,8 +152,11 @@ function initialize(dotNetObjectRef, element, elementId, options) {
                         videoCode = videoCode + '</div>';
                         return videoCode;
                     }
-                    else
-                        return code;
+                    else if (lang && hljsInstalled) {
+                        const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+                        return hljs.highlight(code, { language }).value;
+                    }
+                    return code;
                 }
             }
         },
@@ -271,6 +270,14 @@ function initialize(dotNetObjectRef, element, elementId, options) {
         imageUploadNotifier: imageUploadNotifier
     };
 
+    if (options.preview === true) {
+        // Set initial state to preview if requested
+        const isActive = easyMDE.isPreviewActive()
+        if (!isActive) {
+            easyMDE.togglePreview();
+        }
+    }
+
     // update the first time
     var text = easyMDE.value();
     dotNetObjectRef.invokeMethodAsync("UpdateInternalValue", text, easyMDE.options.previewRender(text));
@@ -296,6 +303,34 @@ function deleteAllAutoSave() {
             localStorage.removeItem(key);
         }
     });
+}
+
+/**
+ * Toggles preview for the specified element
+ * @param {string} elementId
+ */
+function togglePreview(elementId) {
+    const instance = _instances[elementId];
+    if (instance && instance.editor) {
+        instance.editor.togglePreview();
+    }
+}
+
+/**
+ * Acticates or deactives preview mode for the specified element
+ * @param {string} elementId
+ * @param {boolean} wantedState
+ */
+function setPreview(elementId, wantedState) {
+    const instance = _instances[elementId];
+    if (instance && instance.editor) {
+
+        const isActive = instance.editor.isPreviewActive()
+
+        if (isActive != wantedState) {
+            instance.editor.togglePreview();
+        }
+    }
 }
 
 function destroy(element, elementId) {


### PR DESCRIPTION
This is a fix for issue #54.

Changes:
1. In the demo app, a button was added to toggle the visibility of the <MarkdownEditor>
2. In markdownEditor.js, the markdown editor is converted back into a text area in the destroy() function:

```js
function destroy(element, elementId) {
    const instances = _instances || {};

    // Fix for #54: Remove from DOM when MarkdownEditor is disposed
    const instance = _instances[elementId];
    if (instance && instance.editor) {
        instance.editor.toTextArea();
    }

    delete instances[elementId];
}
```

This change allows toggling the visibility from the .razor file without creating duplicate editors.